### PR TITLE
allow inline-string type assignment for txRequests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,8 @@
         "noUnusedVariables": "error"
       },
       "complexity": {
-        "noForEach": "off"
+        "noForEach": "off",
+        "noBannedTypes": "off"
       },
       "performance": {
         "noDelete": "off"
@@ -50,7 +51,8 @@
         "noArrayIndexKey": "off",
         "noAssignInExpressions": "off",
         "noExplicitAny": "off",
-        "noRedeclare": "off"
+        "noRedeclare": "off",
+        "noConfusingVoidType": "off"
       }
     }
   },

--- a/src/chains/suave/parsers.ts
+++ b/src/chains/suave/parsers.ts
@@ -1,4 +1,3 @@
-// import { isAddress, isHex } from '~viem/index.js'
 import {
   InvalidSerializedTransactionError,
   InvalidSerializedTransactionTypeError,
@@ -10,8 +9,8 @@ import { hexToBigInt, hexToNumber } from '../../utils/encoding/fromHex.js'
 import { parseTransaction } from '../../utils/transaction/parseTransaction.js'
 import { toTransactionArray } from '../../utils/transaction/parseTransaction.js'
 import {
+  SuaveTxRequestTypes,
   type SuaveTxType,
-  SuaveTxTypes,
   type TransactionSerializableSuave,
   type TransactionSerializedSuave,
 } from './types.js'
@@ -28,7 +27,7 @@ const safeHexToNumber = (hex: Hex) => {
 
 export const parseSignedComputeRequest = (signedComputeRequest: Hex) => {
   const serializedType = signedComputeRequest.slice(0, 4)
-  if (serializedType !== SuaveTxTypes.ConfidentialRequest) {
+  if (serializedType !== SuaveTxRequestTypes.ConfidentialRequest) {
     throw new InvalidSerializedTransactionTypeError({
       serializedType: serializedType as Hex,
     })
@@ -105,7 +104,7 @@ export function parseTransactionSuave(
 ): ParseTransactionSuaveReturnType<SuaveTxType> {
   const serializedType = serializedTransaction.slice(0, 4)
   const parsedTx =
-    serializedType === SuaveTxTypes.ConfidentialRequest
+    serializedType === SuaveTxRequestTypes.ConfidentialRequest
       ? (parseSignedComputeRequest(
           serializedTransaction,
         ) as ParseTransactionSuaveReturnType<'0x43'>)

--- a/src/chains/suave/serializers.ts
+++ b/src/chains/suave/serializers.ts
@@ -8,6 +8,7 @@ import {
   InvalidConfidentialRequestError,
 } from './errors/transaction.js'
 import {
+  SuaveTxRequestTypes,
   SuaveTxTypes,
   type TransactionSerializableSuave,
   type TransactionSerializedSuave,
@@ -88,8 +89,8 @@ export const serializeConfidentialComputeRecord = (
  */
 export const serializeConfidentialComputeRequest = (
   transaction: TransactionSerializableSuave,
-): TransactionSerializedSuave<SuaveTxTypes.ConfidentialRequest> => {
-  if (transaction.type !== SuaveTxTypes.ConfidentialRequest) {
+): TransactionSerializedSuave<SuaveTxRequestTypes.ConfidentialRequest> => {
+  if (transaction.type !== SuaveTxRequestTypes.ConfidentialRequest) {
     throw new InvalidSerializedTransactionTypeError({
       serializedType: transaction.type,
     })
@@ -167,9 +168,9 @@ export const serializeConfidentialComputeRequest = (
     safeHex(transaction.confidentialInputs),
   ]
   return concatHex([
-    SuaveTxTypes.ConfidentialRequest,
+    SuaveTxRequestTypes.ConfidentialRequest,
     toRlp(preSerializedTransaction),
-  ]) as TransactionSerializedSuave<SuaveTxTypes.ConfidentialRequest>
+  ]) as TransactionSerializedSuave<SuaveTxRequestTypes.ConfidentialRequest>
 }
 
 /* The following does not work. It's left here as a reminder of how it typically should be written,

--- a/src/chains/suave/types.ts
+++ b/src/chains/suave/types.ts
@@ -13,13 +13,26 @@ import type {
 
 /// CUSTOM OVERRIDES ===========================================================
 
+export enum SuaveTxRequestTypes {
+  Legacy = '0x0',
+  ConfidentialRequest = '0x43',
+}
+
 export enum SuaveTxTypes {
   ConfidentialRecord = '0x42',
-  ConfidentialRequest = '0x43',
   Suave = '0x50',
 }
 
-export type SuaveTxType = '0x0' | `${SuaveTxTypes}`
+const AllSuaveTypes = {
+  ...SuaveTxRequestTypes,
+  ...SuaveTxTypes,
+}
+
+// syntactical sugar to allow inline string literals
+export type SuaveTxType =
+  `${(typeof AllSuaveTypes)[keyof typeof AllSuaveTypes]}`
+export type SuaveTxRequestType =
+  `${(typeof SuaveTxRequestTypes)[keyof typeof SuaveTxRequestTypes]}`
 
 type ConfidentialOverrides = {
   kettleAddress?: Address
@@ -144,7 +157,7 @@ export type ConfidentialComputeRecordRpc<TPending extends boolean = false> =
 export type TransactionRequestSuave<
   TQuantity = bigint,
   TIndex = number,
-  TType extends SuaveTxType = SuaveTxTypes.ConfidentialRequest | '0x0',
+  TType extends SuaveTxRequestType = SuaveTxRequestType,
 > = TransactionRequestBase<TQuantity, TIndex, TType> &
   ConfidentialComputeRequestOverrides & {
     accessList?: AccessList

--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -17,6 +17,7 @@ import {
   serializeConfidentialComputeRequest,
 } from './serializers.js'
 import {
+  SuaveTxRequestTypes,
   SuaveTxTypes,
   type TransactionRequestSuave,
   type TransactionSerializableSuave,
@@ -118,7 +119,7 @@ export function getSuaveWallet<
       })
     },
     async signTransaction(txRequest: TransactionRequestSuave) {
-      if (txRequest.type === SuaveTxTypes.ConfidentialRequest) {
+      if (txRequest.type === SuaveTxRequestTypes.ConfidentialRequest) {
         const confidentialInputs = txRequest.confidentialInputs || '0x'
 
         // determine signing method based on transport type
@@ -138,7 +139,7 @@ export function getSuaveWallet<
         return serializeConfidentialComputeRequest({
           ...presignTx,
           confidentialInputs,
-          type: SuaveTxTypes.ConfidentialRequest,
+          type: SuaveTxRequestTypes.ConfidentialRequest,
           r,
           s,
           v,


### PR DESCRIPTION
so now you can write a txRequest like
```
const txReq: TransactionRequestSuave = {
    to: '0x0000000000000000000000000000000000000000',
    value: 0n,
    data: '0x',
    gasPrice: 0n,
    confidentialInputs: '0x',
    kettleAddress: '0x0000000000000000000000000000000000000000',
    type: '0x43' // <-- this!
}
```

prior to this, you'd have to set type with `'0x43' as any` or `'0x43' as SuaveTxType` or `type: SuaveTxTypes.ConfidentialRequest`