### PR TITLE
fix signTransaction (broken for custom transports signing type-0 txs)

### DIFF
--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -361,8 +361,11 @@ function newSuaveWallet<TTransport extends Transport>(params: {
           v,
         })
       } else {
-        if (client.account.type === "local") {
-          return await client.account.signTransaction({...txRequest, type: txRequest.maxPriorityFeePerGas ? 'eip1559' : '0x0'})
+        if (client.account.type === 'local') {
+          return await client.account.signTransaction({
+            ...txRequest,
+            type: txRequest.maxPriorityFeePerGas ? 'eip1559' : '0x0',
+          })
         } else {
           throw new Error('Unsupported transport for manual signTransaction')
         }

--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -266,11 +266,15 @@ function newSuaveWallet<TTransport extends Transport>(params: {
     async sendTransaction(txRequest: TransactionRequestSuave): Promise<Hash> {
       // signTransaction also invokes prepareTxRequest, but only for CCRs. this is still needed for standard txs.
       const payload = await this.prepareTxRequest(txRequest)
-      const signedTx = await this.signTransaction(payload)
-      return this.customProvider.request({
-        method: 'eth_sendRawTransaction',
-        params: [signedTx as Hex],
-      })
+      if (txRequest.type === SuaveTxRequestTypes.ConfidentialRequest) {
+        const signedTx = await this.signTransaction(payload)
+        return this.customProvider.request({
+          method: 'eth_sendRawTransaction',
+          params: [signedTx as Hex],
+        })
+      } else {
+        return client.sendTransaction(payload)
+      }
     },
 
     /** Sign a transaction request. */
@@ -357,10 +361,11 @@ function newSuaveWallet<TTransport extends Transport>(params: {
           v,
         })
       } else {
-        return await client.account.signTransaction({
-          ...txRequest,
-          type: txRequest.type ?? txRequest.maxFeePerGas ? '0x2' : '0x0',
-        })
+        if (client.account.type === "local") {
+          return await client.account.signTransaction({...txRequest, type: txRequest.maxPriorityFeePerGas ? 'eip1559' : '0x0'})
+        } else {
+          throw new Error('Unsupported transport for manual signTransaction')
+        }
       }
     },
   }))


### PR DESCRIPTION
Fixes the `client.account.signTransaction is not a function` error.
The `account.signTransaction` function is only available to local accounts. EIP-1193 (browser) accounts needed to call the native `client.sendTransaction` function to send traditional txs.