### PR TITLE
bugfix/prepareTx

### DIFF
--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -207,20 +207,17 @@ function newSuaveWallet<TTransport extends Transport>(params: {
           console.warn('no gas provided, using default 30000000')
           return 30000000n
         })()
-      const preparedTx = await this.customProvider.prepareTransactionRequest({
-        account: client.account,
-        ...txRequest,
-        gas,
-      })
-      const gasPrice =
-        preparedTx.gasPrice ?? (await this.customProvider.getGasPrice())
+
+      const from = txRequest.from ?? client.account.address
+
       return {
         ...txRequest,
-        from: txRequest.from ?? preparedTx.from,
-        nonce: txRequest.nonce ?? preparedTx.nonce,
-        gas: txRequest.gas ?? preparedTx.gas,
-        gasPrice: txRequest.gasPrice ?? gasPrice,
+        from,
+        nonce: txRequest.nonce ?? (await this.customProvider.getTransactionCount({address: from})),
+        gas,
+        gasPrice: txRequest.gasPrice ?? (await this.customProvider.getGasPrice()),
         chainId: txRequest.chainId ?? suaveRigil.id,
+        type: txRequest.type ?? txRequest.kettleAddress ? SuaveTxRequestTypes.ConfidentialRequest : '0x0',
       }
     },
 

--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -213,11 +213,17 @@ function newSuaveWallet<TTransport extends Transport>(params: {
       return {
         ...txRequest,
         from,
-        nonce: txRequest.nonce ?? (await this.customProvider.getTransactionCount({address: from})),
+        nonce:
+          txRequest.nonce ??
+          (await this.customProvider.getTransactionCount({ address: from })),
         gas,
-        gasPrice: txRequest.gasPrice ?? (await this.customProvider.getGasPrice()),
+        gasPrice:
+          txRequest.gasPrice ?? (await this.customProvider.getGasPrice()),
         chainId: txRequest.chainId ?? suaveRigil.id,
-        type: txRequest.type ?? txRequest.kettleAddress ? SuaveTxRequestTypes.ConfidentialRequest : '0x0',
+        type:
+          txRequest.type ?? txRequest.kettleAddress
+            ? SuaveTxRequestTypes.ConfidentialRequest
+            : '0x0',
       }
     },
 


### PR DESCRIPTION
fixes error arising from `wallet.prepareTx` when calling the inner getBlock action (observed using type-0 txs)
- **replace client.prepareTransactionRequest w/ customProvider calls**
