### PR TITLE
Fix chain in SuaveWallet if a chain was passed explicitly

### DIFF
--- a/.changeset/curly-students-return.md
+++ b/.changeset/curly-students-return.md
@@ -1,0 +1,5 @@
+---
+"@flashbots/suave-viem": patch
+---
+
+Fix chain in suave wallet

--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -196,9 +196,10 @@ function newSuaveWallet<TTransport extends Transport>(params: {
   const account = params.jsonRpcAccount || privateKeyAccount
 
   const clientChain =
-    params.chain || params.customRpc?.includes('localhost')
+    params.chain || (params.customRpc?.includes('localhost')
       ? suaveRigil
       : suaveToliman
+    )
 
   return createWalletClient({
     account,

--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -196,10 +196,8 @@ function newSuaveWallet<TTransport extends Transport>(params: {
   const account = params.jsonRpcAccount || privateKeyAccount
 
   const clientChain =
-    params.chain || (params.customRpc?.includes('localhost')
-      ? suaveRigil
-      : suaveToliman
-    )
+    params.chain ||
+    (params.customRpc?.includes('localhost') ? suaveRigil : suaveToliman)
 
   return createWalletClient({
     account,


### PR DESCRIPTION
Previously, when creating a wallet with `getSuaveWallet` and passing a `chain` argument, created `wallet.chain` would always be set to Rigil, no matter what was passed.