### PR TITLE
Fix transaction type in prepareTxRequest

### DIFF
--- a/.changeset/afraid-socks-buy.md
+++ b/.changeset/afraid-socks-buy.md
@@ -1,0 +1,5 @@
+---
+"@flashbots/suave-viem": patch
+---
+
+Fix sending Legacy transactions

--- a/src/chains/suave/wallet.ts
+++ b/src/chains/suave/wallet.ts
@@ -253,9 +253,10 @@ function newSuaveWallet<TTransport extends Transport>(params: {
           txRequest.gasPrice ?? (await this.customProvider.getGasPrice()),
         chainId: txRequest.chainId ?? client.chain.id,
         type:
-          txRequest.type ?? txRequest.kettleAddress
+          txRequest.type ??
+          (txRequest.kettleAddress
             ? SuaveTxRequestTypes.ConfidentialRequest
-            : '0x0',
+            : '0x0'),
       }
     },
 


### PR DESCRIPTION
Previously it would be set to ConfidentialRequest, even if Legacy was explicitly chosen.